### PR TITLE
Fix unclosed session

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/samples/replication/impl/SampleReplicationPreprocessor.java
+++ b/bundle/src/main/java/com/adobe/acs/samples/replication/impl/SampleReplicationPreprocessor.java
@@ -90,7 +90,7 @@ public class SampleReplicationPreprocessor implements Preprocessor {
             // To prevent Replication from happening, throw a ReplicationException
             throw new ReplicationException(e);
         } finally {
-            if (resourceResolver == null) {
+                if (resourceResolver != null && resourceResolver.isLive()) {
                 // Always close resource resolver you open
                 resourceResolver.close();
             }


### PR DESCRIPTION
Original implementation was only calling resourceResolver.close() if the resourceResolver was null.
