### PR TITLE
Update SampleJsonHitWriter.java

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/samples/querybuilder/impl/SampleJsonHitWriter.java
+++ b/bundle/src/main/java/com/adobe/acs/samples/querybuilder/impl/SampleJsonHitWriter.java
@@ -46,7 +46,7 @@ import javax.jcr.RepositoryException;
 
     An example call to this Sample HitWriter might look like:
 
-        http://localhost:4502/bin/querybuilder.json?...&p.hitwriter=acs-commons-sample
+        http://localhost:4502/bin/querybuilder.json?...&p.hitwriter=acs-aem-commons-sample
 
     Resulting JSON object would look like:
 


### PR DESCRIPTION
Modify comment to correct the example invocation, so that the p.hitwriter parameter value matches the name that the hitwriter has been registered under.
