### PR TITLE
Update to release version of AEM 6.3 uber-jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
             <dependency>
                 <groupId>com.adobe.aem</groupId>
                 <artifactId>uber-jar</artifactId>
-                <version>6.3.0-load21b</version>
+                <version>6.3.0</version>
                 <scope>provided</scope>
                 <classifier>apis</classifier>
             </dependency>


### PR DESCRIPTION
version 6.3.0-load21b is not available in the public repos