### PR TITLE
Fixed code sample.

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/samples/servlets/impl/SlingPostProcessorSample.java
+++ b/bundle/src/main/java/com/adobe/acs/samples/servlets/impl/SlingPostProcessorSample.java
@@ -30,7 +30,10 @@ public class SlingPostProcessorSample implements SlingPostProcessor {
         if (accepts(request)) {
 
             // Apply your custom changes: first, adapt the resource to a ModifiableValueMap
-            // You need to get the resource from the ResourceResolver for the adaptTo to work. 
+            // You need to get the resource from the ResourceResolver for the adaptTo to work.
+
+
+
             final Resource resource = request.getResourceResolver().getResource( request.getResource().getPath() );
             final ModifiableValueMap properties = resource.adaptTo(ModifiableValueMap.class);
 

--- a/bundle/src/main/java/com/adobe/acs/samples/servlets/impl/SlingPostProcessorSample.java
+++ b/bundle/src/main/java/com/adobe/acs/samples/servlets/impl/SlingPostProcessorSample.java
@@ -31,9 +31,7 @@ public class SlingPostProcessorSample implements SlingPostProcessor {
 
             // Apply your custom changes: first, adapt the resource to a ModifiableValueMap
             // You need to get the resource from the ResourceResolver for the adaptTo to work.
-
-
-
+            // The best way to get the path is from the Modifications list instead of request.getResource().getPath()
             final Resource resource = request.getResourceResolver().getResource( request.getResource().getPath() );
             final ModifiableValueMap properties = resource.adaptTo(ModifiableValueMap.class);
 

--- a/bundle/src/main/java/com/adobe/acs/samples/servlets/impl/SlingPostProcessorSample.java
+++ b/bundle/src/main/java/com/adobe/acs/samples/servlets/impl/SlingPostProcessorSample.java
@@ -30,7 +30,8 @@ public class SlingPostProcessorSample implements SlingPostProcessor {
         if (accepts(request)) {
 
             // Apply your custom changes: first, adapt the resource to a ModifiableValueMap
-            final Resource resource = request.getResource();
+            // You need to get the resource from the ResourceResolver for the adaptTo to work. 
+            final Resource resource = request.getResourceResolver().getResource( request.getResource().getPath() );
             final ModifiableValueMap properties = resource.adaptTo(ModifiableValueMap.class);
 
             // Example: add an additional property to the resource


### PR DESCRIPTION
The code sample suggest getting the resource with `request.getResource` and then adapting to ModifiableValueMap, but that doesn't work. The update shows how to get the resource for the adaptTo method to work. 